### PR TITLE
タスク編集、削除機能の実装

### DIFF
--- a/todo/static/js/edit.js
+++ b/todo/static/js/edit.js
@@ -1,0 +1,38 @@
+function editFunction(ele) {
+  var task_id = ele.id;
+  const div = document.getElementById("form_box_" + task_id);
+  const task_name = document.getElementById("task_" + task_id).innerText;
+  if (!div.hasChildNodes()){
+    const div2 = document.createElement("div");
+    const input_task = document.createElement("input");
+    input_task.setAttribute("value",task_name);
+    input_task.setAttribute("name", "task");
+    input_task.setAttribute("type", "text");
+    input_task.setAttribute("class", "form-control");
+    div2.setAttribute("class", "col");
+    
+    const input_target = document.createElement("input");
+    const div3 = document.createElement("div");
+    input_target.setAttribute("type", "datetime-local");
+    input_target.setAttribute("name", "target");
+    input_target.setAttribute("class", "form-control");
+    input_target.setAttribute("style", "width: 70%;");
+    div3.setAttribute("class", "col");
+
+    const submit = document.createElement("input");
+    submit.setAttribute("type", "submit");
+    submit.setAttribute("value", "反映");
+    submit.setAttribute("class", "btn btn-info");
+
+    div2.appendChild(input_task);
+    div.appendChild(div2);
+    div3.appendChild(input_target);
+    div.appendChild(div3);
+    div.appendChild(submit);
+
+    ele.innerText = "閉じる"
+  } else {
+    ele.innerText = "編集"
+    while (div) div.removeChild(div.firstChild);
+  }
+}

--- a/todo/templates/todo/base.html
+++ b/todo/templates/todo/base.html
@@ -1,3 +1,5 @@
+{% load static %}
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -19,5 +21,6 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="{% static 'js/edit.js' %}"></script>
   </body>
 </html>

--- a/todo/templates/todo/index.html
+++ b/todo/templates/todo/index.html
@@ -11,27 +11,38 @@
 {% endblock header %}
 {% block content %}
 <div class='container'> 
-  <div class="alert alert-info">
-    <form action="{% url 'new'  %}" method="post">
+  <div class="alert alert-info" style="width: 70%; margin: 20px auto; text-align: center;">
+    <form action="{% url 'new'  %}" method="POST">
       {% csrf_token %}
-        <div>
+      <div class="row">
+        <div class="col">
           <label for="new_task">タスク内容</label><br>
-          <input type="text" name="task" id="new_task" value='' placeholder="業務内容">
+          <input type="text" name="task" class="form-control" id="new_task" value='' placeholder="取り組むタスクを入力">
         </div>
-        <div>
+        <div class="col">
           <label for="new_target">期限</label><br>
-          <input type="datetime-local" name="target", id="new_target">
+          <input type="datetime-local" class="form-control" name="target", id="new_target">
         </div>
-    <input type="submit" value="add">
+      </div>
+    <input type="submit" value="タスクを追加" class="btn btn-primary" style="margin-top: 5px;">
     </form>
   </div>
 {% for task in latest_task_list %}
 <div class="alert alert-info" role="alert">
-  <input type="checkbox" name="completed" value='True' style="float: left; margin: 6px 4px;">
-  <p>{{ task.task }}<span class="badge badge-danger" style="font-size: 15px; margin-left: 5px;">期限：{{ task.target }}</span></P>
-  <a href="#" class="btn btn-primary" tabindex="-1" role="button" aria-disabled="true">編集</a>
-  <a href="#" class="btn btn-success" tabindex="-1" role="button" aria-disabled="true">削除</a>
-  <a href="#" class="btn btn-info" tabindex="-1" role="button" aria-disabled="true">詳細</a>
+  <div style="margin-bottom: 5px;">
+    <input type="checkbox" name="completed" value='True' style="float: left; margin: 6px 4px;">
+    <p id="task_{{ task.id }}" style="display: inline;">{{ task.task }}</p>
+    <p class="badge badge-danger" id="target_{{ task.id }}" style="font-size: 15px; margin-left: 5px; display: inline;">期限：{{ task.target|date:"Y-m-j H:i" }}</p>
+  </div>
+  <form action="{% url 'edit' task.pk %}" method="POST">
+    {% csrf_token %}
+    <div id="form_box_{{task.id}}" class="row"></div>
+  </form>
+  <a type="button" class="btn btn-primary" id="{{task.id}}" onclick="editFunction(this)" style="color: white;">編集</a>
+  <form action="{% url 'delete' task.pk %}" method="POST" class="btn">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-success" aria-disabled="true" onclick='return confirm("本当に削除しますか？");'>削除</button>
+  </form>
 </div>
 {% endfor %}
 </div>

--- a/todo/urls.py
+++ b/todo/urls.py
@@ -4,5 +4,7 @@ from . import views
 
 urlpatterns = [
   path('', views.index, name='index'),
-  path('new/', views.new, name='new')
+  path('new/', views.new, name='new'),
+  path('delete/<int:task_id>', views.delete, name='delete'),
+  path('edit/<int:task_id>', views.edit, name='edit'), 
 ]

--- a/todo/views.py
+++ b/todo/views.py
@@ -1,13 +1,11 @@
-from django.shortcuts import render
-# from django.shortcuts import render_to_response
+from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.template import RequestContext
 from .forms import TaskForm
 from .models import Task
 
 def index(request):
-  latest_task_list = Task.objects.all()
+  latest_task_list = Task.objects.order_by('-target').reverse()
   context = {'latest_task_list': latest_task_list}
   return render(request, 'todo/index.html', context)
 
@@ -20,7 +18,24 @@ def new(request):
       form.save()
       return HttpResponseRedirect(reverse('index'))
 
-  return render(request, 'todo/index.html',
-                           {'latest_task_list': latest_task_list, 'form': form})
+  return render(request, 'todo/index.html', {'latest_task_list': latest_task_list, 'form': form})
 
-  
+
+def delete(request, task_id):
+  task = get_object_or_404(Task, pk=task_id)
+  task.delete()
+  return HttpResponseRedirect(reverse('index'))
+
+def edit(request, task_id):
+  if request.method == 'POST':
+    task = Task.objects.get(pk=task_id)
+    print(task)
+    print(request.POST)
+    task.task=request.POST['task']
+    task.target=request.POST['target']
+    task.save()
+    return HttpResponseRedirect(reverse('index'))
+  else:
+    latest_task_list = Task.objects.all()
+    context = {'latest_task_list': latest_task_list}
+    return render(request, 'todo/index.html', context)


### PR DESCRIPTION
投稿済みのタスクの編集と削除の機能の実装を行なった。
urls.pyにeditとdeleteのパスを追加。
views.pyにedit関数、delete関数を追加。
編集用の入力フォームはjavascriptで実装。（static/js/edit.jsに記述）
投稿したタスクの期限が近いものから順にsortさせた。

---

<img width="1185" alt="スクリーンショット 2020-10-06 16 43 39" src="https://user-images.githubusercontent.com/55049751/95173057-268aa580-07f3-11eb-8beb-34055e25027f.png">
